### PR TITLE
feat(auth): Implement backend and frontend refresh token logic

### DIFF
--- a/apps/iot-app/src/App.tsx
+++ b/apps/iot-app/src/App.tsx
@@ -6,6 +6,7 @@ import PatientDetail from "./components/PatientDetailComponent/PatientDetailComp
 import ProtectedRoute from "./components/ProtectedRoute";
 import LoginPage from "./pages/LoginPage";
 import MainPage from "./pages/MainPage/MainPage";
+import ProfilePage from "./pages/ProfilePage";
 import RegisterPage from "./pages/RegisterPage";
 
 function App() {
@@ -20,6 +21,7 @@ function App() {
           <Route path="/" element={<MainPage />}>
             <Route index element={<HomePage />} />
             <Route path="patient-detail/:id" element={<PatientDetail />} />
+            <Route path="profile" element={<ProfilePage />} />
           </Route>
         </Route>
       </Routes>

--- a/apps/iot-app/src/api/axiosConfig.ts
+++ b/apps/iot-app/src/api/axiosConfig.ts
@@ -1,4 +1,6 @@
-import axios from "axios";
+import { toast } from "react-hot-toast";
+
+import axios, { InternalAxiosRequestConfig } from "axios";
 
 const apiClient = axios.create({
   baseURL: "http://localhost:3000",
@@ -6,7 +8,7 @@ const apiClient = axios.create({
 
 apiClient.interceptors.request.use(
   config => {
-    const token = localStorage.getItem("authToken");
+    const token = localStorage.getItem("accessToken");
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -17,16 +19,82 @@ apiClient.interceptors.request.use(
   },
 );
 
+let isRefreshing = false;
+let failedQueue: { resolve: (value: unknown) => void; reject: (reason?: Error) => void }[] = [];
+
+const processQueue = (error: Error | null, token: string | null = null) => {
+  failedQueue.forEach(prom => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
 apiClient.interceptors.response.use(
   response => response,
-  error => {
-    if (error.response && error.response.status === 401) {
-      localStorage.removeItem("authToken");
-      if (window.location.pathname !== "/login") {
-        window.location.href = "/login";
+  async error => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then(token => {
+            originalRequest.headers["Authorization"] = "Bearer " + token;
+            return apiClient(originalRequest);
+          })
+          .catch(err => {
+            return Promise.reject(err);
+          });
       }
-      return Promise.reject(new Error("Session expired or invalid. Please log in again."));
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      const refreshToken = localStorage.getItem("refreshToken");
+      if (!refreshToken) {
+        isRefreshing = false;
+        localStorage.removeItem("accessToken");
+        localStorage.removeItem("refreshToken");
+        delete apiClient.defaults.headers.common["Authorization"];
+        window.location.href = "/login";
+        return Promise.reject(new Error("No refresh token available."));
+      }
+
+      try {
+        const refreshResponse = await axios.post<{ accessToken: string }>(
+          "http://localhost:3000/api/auth/refresh",
+          { refreshToken },
+          {
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+
+        const newAccessToken = refreshResponse.data.accessToken;
+        localStorage.setItem("accessToken", newAccessToken);
+        apiClient.defaults.headers.common["Authorization"] = `Bearer ${newAccessToken}`;
+        originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+        processQueue(null, newAccessToken);
+        return apiClient(originalRequest);
+      } catch (refreshError) {
+        const errorToProcess =
+          refreshError instanceof Error ? refreshError : new Error("Token refresh failed");
+        processQueue(errorToProcess, null);
+        localStorage.removeItem("accessToken");
+        localStorage.removeItem("refreshToken");
+        delete apiClient.defaults.headers.common["Authorization"];
+        toast.error("Session expired. Please log in again.");
+        window.location.href = "/login";
+        return Promise.reject(errorToProcess);
+      } finally {
+        isRefreshing = false;
+      }
     }
+
     return Promise.reject(error);
   },
 );

--- a/apps/iot-app/src/context/AuthContext.tsx
+++ b/apps/iot-app/src/context/AuthContext.tsx
@@ -8,23 +8,31 @@ import React, {
 } from "react";
 import toast from "react-hot-toast";
 
+import { AxiosError } from "axios";
+
 import apiClient from "../api/axiosConfig";
 import LoadingOverlay from "../components/LoadingOverlay";
 
 interface User {
   userId: string;
-  role: "admin" | "user"; 
+  role: "admin" | "user";
   username?: string;
   email?: string;
+}
+
+interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
 }
 
 interface AuthContextType {
   isAuthenticated: boolean;
   user: User | null;
-  token: string | null;
-  login: (token: string) => Promise<void>; 
+  accessToken: string | null;
+  refreshToken: string | null;
+  login: (tokens: AuthTokens) => Promise<void>;
   logout: () => void;
-  isLoading: boolean; 
+  isLoading: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -34,73 +42,87 @@ interface AuthProviderProps {
 }
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
-  const [token, setToken] = useState<string | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState<string | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   const logout = useCallback(() => {
-    localStorage.removeItem("authToken");
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
     delete apiClient.defaults.headers.common["Authorization"];
-    setToken(null);
+    setAccessToken(null);
+    setRefreshToken(null);
     setUser(null);
     toast.success("Logged out successfully");
   }, []);
 
   const fetchUser = useCallback(
     async (currentToken: string | null) => {
-      const targetToken = currentToken || localStorage.getItem("authToken");
-      if (!targetToken) {
-        delete apiClient.defaults.headers.common["Authorization"];
-        setToken(null);
-        setUser(null);
+      if (!currentToken) {
+        if (accessToken) logout();
         return;
       }
 
-      apiClient.defaults.headers.common["Authorization"] = `Bearer ${targetToken}`;
+      apiClient.defaults.headers.common["Authorization"] = `Bearer ${currentToken}`;
       try {
         const response = await apiClient.get<User>("/api/auth/me");
-        if (localStorage.getItem("authToken") === targetToken) {
-          setToken(targetToken);
+        if (localStorage.getItem("accessToken") === currentToken) {
+          setAccessToken(currentToken);
           setUser(response.data);
         } else {
           logout();
         }
       } catch (error) {
-        console.error("Failed to fetch user or token expired:", error);
-        localStorage.removeItem("authToken");
-        delete apiClient.defaults.headers.common["Authorization"];
-        setToken(null);
-        setUser(null);
+        console.error("Failed to fetch user (likely token expired/invalid):", error);
+        if (!(error instanceof AxiosError) || error.response?.status !== 401) {
+          logout();
+        }
       }
     },
-    [logout],
+    [logout, accessToken],
   );
 
   useEffect(() => {
     const loadAuthData = async () => {
-      await fetchUser(null);
+      setIsLoading(true);
+      const storedAccessToken = localStorage.getItem("accessToken");
+      const storedRefreshToken = localStorage.getItem("refreshToken");
+      setRefreshToken(storedRefreshToken);
+
+      if (storedAccessToken) {
+        await fetchUser(storedAccessToken);
+      }
+
       setIsLoading(false);
     };
     loadAuthData();
   }, [fetchUser]);
 
   const login = useCallback(
-    async (newToken: string) => {
-      localStorage.setItem("authToken", newToken);
-      await fetchUser(newToken);
+    async (tokens: AuthTokens) => {
+      localStorage.setItem("accessToken", tokens.accessToken);
+      localStorage.setItem("refreshToken", tokens.refreshToken);
+      setAccessToken(tokens.accessToken);
+      setRefreshToken(tokens.refreshToken);
+      await fetchUser(tokens.accessToken);
     },
     [fetchUser],
   );
 
-  if (isLoading) {
-    return <LoadingOverlay />;
-  }
-
   return (
     <AuthContext.Provider
-      value={{ isAuthenticated: !!token, user, token, login, logout, isLoading }}
+      value={{
+        isAuthenticated: !!accessToken,
+        user,
+        accessToken,
+        refreshToken,
+        login,
+        logout,
+        isLoading,
+      }}
     >
-      {children}
+      {!isLoading ? children : <LoadingOverlay />}
     </AuthContext.Provider>
   );
 };

--- a/apps/iot-app/src/functions/ThemeContext.tsx
+++ b/apps/iot-app/src/functions/ThemeContext.tsx
@@ -10,30 +10,39 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [theme, setTheme] = useState<Theme>("light");
+  const [theme, setTheme] = useState<Theme>(() => {
+    const storedTheme = localStorage.getItem("theme") as Theme | null;
+    return storedTheme === "light" || storedTheme === "dark" ? storedTheme : "light";
+  });
 
   useEffect(() => {
-    const storedTheme = localStorage.getItem("theme") as Theme | null;
-    if (storedTheme === "light" || storedTheme === "dark") {
-      setTheme(storedTheme);
+    const root = window.document.documentElement;
+    const body = window.document.body;
+
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+
+    body.classList.remove(
+      "bg-white",
+      "text-black",
+      "bg-neutral-900",
+      "bg-neutral-800",
+      "text-white",
+    );
+    if (theme === "dark") {
+      body.classList.add("bg-neutral-700", "text-white");
+    } else {
+      body.classList.add("bg-white", "text-black");
     }
-  }, []);
+
+    localStorage.setItem("theme", theme);
+  }, [theme]);
 
   const toggleTheme = () => {
-    const newTheme = theme === "light" ? "dark" : "light";
-    setTheme(newTheme);
-    localStorage.setItem("theme", newTheme);
+    setTheme(prevTheme => (prevTheme === "light" ? "dark" : "light"));
   };
 
-  const bgClass = theme === "light" ? "bg-white text-black" : "bg-neutral-500 text-white";
-
-  return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
-      <div className={`${bgClass}`} style={{ minHeight: "100vh" }}>
-        {children}
-      </div>
-    </ThemeContext.Provider>
-  );
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
 };
 
 // eslint-disable-next-line react-refresh/only-export-components

--- a/apps/iot-app/src/pages/MainPage/MainPage.tsx
+++ b/apps/iot-app/src/pages/MainPage/MainPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { Outlet } from "react-router-dom";
+import { Link, Outlet } from "react-router-dom";
 
 import ArrowLeftIcon from "../../Icons/ArrowLeftIcon";
 import ArrowRightIcon from "../../Icons/ArrowRightIcon";
+import ChevronDownIcon from "../../Icons/ChevronDownIcon";
 import Alert from "../../alerts/Alert";
 import CreateDeviceModal from "../../components/CreateDeviceModal";
 import LoadingOverlay from "../../components/LoadingOverlay";
@@ -16,7 +17,7 @@ export default function MainPage() {
   const [sidebarWidth, setSidebarWidth] = useState(250);
   const { theme, toggleTheme } = useTheme();
   const { user, logout, isLoading } = useAuth();
-  //onst navigate = useNavigate();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
   const [showCreateDeviceModal, setShowCreateDeviceModal] = useState(false);
 
@@ -60,37 +61,78 @@ export default function MainPage() {
         >
           {isSidebarOpen ? <ArrowLeftIcon /> : <ArrowRightIcon />}
         </button>
-        <header className={`p-4 pl-16 border-b ${headerClass} flex items-center justify-between`}>
-          <h1 className="text-2xl font-medium">😊 {user ? `(${user.role})` : ""}</h1>
-          <div className="flex items-center space-x-2 flex-shrink-0">
+        <header
+          className={`p-4 pl-16 border-b ${headerClass} flex items-center justify-between relative`}
+        >
+          <div>{/* Placeholder for left content if needed */}</div>
+          <div className="flex items-center space-x-4 flex-shrink-0">
             <button
               onClick={handleToggleTheme}
               className="bg-gray-600 text-white px-3 py-1 rounded hover:bg-gray-800 hover:shadow-xs hover:shadow-gray-600/50 transition"
             >
-              {theme === "light" ? "Dark" : "Light"}
+              {theme === "light" ? "Tmavý režim" : "Světlý režim"}
             </button>
-            <button
-              onClick={openLogoutModal}
-              className="bg-red-600 text-white px-3 py-1 rounded hover:bg-red-800 hover:shadow-xs hover:shadow-red-600/50 transition"
-            >
-              Logout
-            </button>
+            <div className="relative">
+              <button
+                onClick={() => setIsDropdownOpen(prev => !prev)}
+                className={`${theme === "light" ? "text-black" : "text-white"} flex items-center space-x-1 p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700`}
+              >
+                <span>{user?.username || "User"}</span>
+                <svg
+                  className={`w-4 h-4 transition-transform duration-200 ${isDropdownOpen ? "rotate-180" : ""}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M19 9l-7 7-7-7"
+                  ></path>
+                </svg>
+              </button>
+              {isDropdownOpen && (
+                <div
+                  className={`absolute right-0 mt-2 w-48 ${theme === "light" ? "bg-white" : "bg-neutral-700"} rounded-md shadow-lg py-1 z-20`}
+                  onMouseLeave={() => setIsDropdownOpen(false)}
+                >
+                  <Link
+                    to="/profile"
+                    onClick={() => setIsDropdownOpen(false)}
+                    className={`block px-4 py-2 text-sm ${theme === "light" ? "text-gray-700 hover:bg-gray-100" : "text-gray-200 hover:bg-neutral-600"}`}
+                  >
+                    Profil
+                  </Link>
+                  <button
+                    onClick={() => {
+                      openLogoutModal();
+                      setIsDropdownOpen(false);
+                    }}
+                    className={`block w-full text-left px-4 py-2 text-sm ${theme === "light" ? "text-red-700 hover:bg-gray-100" : "text-red-400 hover:bg-neutral-600"}`}
+                  >
+                    Odhlásit se
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </header>
         <Breadcrumbs />
         <div className={`p-4 border-b ${headerClass} border-t-0`}>
-          <Alert type="warning" title="Warning" message="Possible patient fall!" room="A-105" />
+          <Alert type="warning" title="Varování" message="Možný pád pacienta!" room="A-105" />
           <Alert
             type="low-battery"
-            title="Low battery"
-            message="Sensor battery is below 10%"
+            title="Nízká baterie"
+            message="Baterie senzoru je pod 10%"
             room="B-207"
           />
-          <Alert type="alert-canceled" title="Alert canceled" message="Alert has been dismissed" />
+          <Alert type="alert-canceled" title="Výstraha zrušena" message="Výstraha byla zrušena" />
           <Alert
             type="lost-connection"
-            title="Lost connection"
-            message="Device disconnected from network"
+            title="Ztráta spojení"
+            message="Zařízení odpojeno od sítě"
             room="A-006"
             pacient="antonín komárek"
           />
@@ -100,7 +142,7 @@ export default function MainPage() {
                 onClick={() => setShowCreateDeviceModal(true)}
                 className="bg-green-500 text-black px-4 py-2 rounded-md hover:bg-green-800 hover:shadow-xs"
               >
-                Create Device
+                Vytvořit Zařízení
               </button>
             )}
           </div>
@@ -117,10 +159,10 @@ export default function MainPage() {
             <h3
               className={`text-lg font-medium ${theme === "light" ? "text-gray-900" : "text-white"} mb-4`}
             >
-              Confirm Logout
+              Potvrdit Odhlášení
             </h3>
             <p className={`${theme === "light" ? "text-gray-500" : "text-gray-300"} mb-6`}>
-              Are you sure you want to logout?
+              Opravdu se chcete odhlásit?
             </p>
             <div className="flex justify-end gap-4">
               <button
@@ -131,7 +173,7 @@ export default function MainPage() {
                     : "text-gray-200 bg-neutral-700 hover:bg-neutral-600 focus:ring-neutral-500"
                 } rounded-lg focus:outline-none focus:ring-2 transition-colors duration-200`}
               >
-                Cancel
+                Zrušit
               </button>
               <button
                 onClick={() => {
@@ -140,7 +182,7 @@ export default function MainPage() {
                 }}
                 className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors duration-200"
               >
-                Logout
+                Odhlásit se
               </button>
             </div>
           </div>

--- a/apps/iot-app/src/pages/ProfilePage.tsx
+++ b/apps/iot-app/src/pages/ProfilePage.tsx
@@ -1,0 +1,230 @@
+import React, { useState } from "react";
+// Import form handling, validation, icons, api, toast, strength meter
+import { useForm, useWatch } from "react-hook-form";
+import toast from "react-hot-toast";
+import { AiOutlineEye, AiOutlineEyeInvisible } from "react-icons/ai";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import axios from "axios";
+// Keep for error checking
+import { z } from "zod";
+
+import apiClient from "../api/axiosConfig";
+import PasswordStrengthMeter from "../components/PasswordStrengthMeter";
+import { useAuth } from "../context/AuthContext";
+
+// Re-use or import password validation logic from RegisterPage
+const passwordValidation = z
+  .string()
+  .min(8, { message: "Password must be at least 8 characters long" })
+  .regex(/[a-z]/, { message: "Password must contain at least one lowercase letter" })
+  .regex(/[A-Z]/, { message: "Password must contain at least one uppercase letter" })
+  .regex(/[0-9]/, { message: "Password must contain at least one number" })
+  .regex(/[@$!%*?&]/, {
+    message: "Password must contain at least one special character (@$!%*?&)",
+  });
+
+// Schema for the change password form
+const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, { message: "Současné heslo je povinné" }),
+    newPassword: passwordValidation,
+    confirmNewPassword: z.string(),
+  })
+  .refine(data => data.newPassword === data.confirmNewPassword, {
+    message: "New passwords do not match",
+    path: ["confirmNewPassword"], // Apply error to the confirmation field
+  });
+
+type ChangePasswordFormData = z.infer<typeof changePasswordSchema>;
+
+// TODO: Implement user profile display and editing functionality
+function ProfilePage() {
+  const { user } = useAuth();
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset, // Get reset function from useForm
+    formState: { errors, isSubmitting },
+  } = useForm<ChangePasswordFormData>({
+    resolver: zodResolver(changePasswordSchema),
+    mode: "onBlur", // Validate on blur
+  });
+
+  // Watch the new password value for the strength meter
+  const newPasswordValue = useWatch({ control, name: "newPassword" });
+
+  // States for password visibility toggles
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmNewPassword, setShowConfirmNewPassword] = useState(false);
+
+  // Define the submit handler function
+  const onSubmit = async (data: ChangePasswordFormData) => {
+    try {
+      await apiClient.patch("/api/auth/change-password", {
+        currentPassword: data.currentPassword,
+        newPassword: data.newPassword,
+      });
+      toast.success("Password updated successfully!");
+      reset();
+    } catch (err) {
+      console.error("Password change failed:", err);
+      let errorMessage = "Failed to update password. Please try again.";
+      if (axios.isAxiosError(err) && err.response?.data?.message) {
+        errorMessage = err.response.data.message;
+      } else if (err instanceof Error) {
+        // Potentially handle other errors or just keep generic message
+      }
+      toast.error(errorMessage);
+    }
+  };
+
+  if (!user) {
+    return <div className="p-4">Loading user data...</div>;
+  }
+
+  return (
+    <div className={`p-6 max-w-4xl mx-auto min-h-full`}>
+      <h1 className="text-3xl font-bold mb-6 border-b pb-2">Uživatelský Profil</h1>
+
+      {/* Display User Info */}
+      <div className="mb-8 shadow rounded-lg p-6 border border-gray-200 dark:border-neutral-600">
+        <h2 className="text-xl font-semibold mb-4">Detaily Účtu</h2>
+        <div className="space-y-2">
+          <p>
+            <span className="font-medium">Uživatelské jméno:</span> {user.username}
+          </p>
+          <p>
+            <span className="font-medium">Email:</span> {user.email}
+          </p>
+        </div>
+      </div>
+
+      {/* Change Password Section */}
+      <div className="shadow rounded-lg p-6 border border-gray-200 dark:border-neutral-600">
+        <h2 className="text-xl font-semibold mb-4">Změnit Heslo</h2>
+        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
+          {/* Current Password */}
+          <div className="relative">
+            <label htmlFor="currentPassword" className="block text-sm font-medium mb-1">
+              Současné Heslo
+            </label>
+            <div className="relative">
+              <input
+                type={showCurrentPassword ? "text" : "password"}
+                id="currentPassword"
+                {...register("currentPassword")}
+                className={`shadow-sm appearance-none border ${errors.currentPassword ? "border-red-500" : "border-gray-400 dark:border-neutral-600"} rounded w-full py-2 px-3 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50 pr-10`}
+                required
+                disabled={isSubmitting}
+                aria-invalid={errors.currentPassword ? "true" : "false"}
+              />
+              <button
+                type="button"
+                onClick={() => setShowCurrentPassword(prev => !prev)}
+                className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-gray-700"
+                aria-label={
+                  showCurrentPassword ? "Skrýt současné heslo" : "Zobrazit současné heslo"
+                }
+              >
+                {showCurrentPassword ? (
+                  <AiOutlineEyeInvisible size={20} />
+                ) : (
+                  <AiOutlineEye size={20} />
+                )}
+              </button>
+            </div>
+            {errors.currentPassword && (
+              <p className="text-red-500 text-xs italic mt-1">{errors.currentPassword.message}</p>
+            )}
+          </div>
+
+          {/* New Password */}
+          <div className="relative">
+            <label htmlFor="newPassword" className="block text-sm font-medium mb-1">
+              Nové Heslo
+            </label>
+            <div className="relative">
+              <input
+                type={showNewPassword ? "text" : "password"}
+                id="newPassword"
+                {...register("newPassword")}
+                className={`shadow-sm appearance-none border ${errors.newPassword ? "border-red-500" : "border-gray-400 dark:border-neutral-600"} rounded w-full py-2 px-3 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50 pr-10`}
+                required
+                disabled={isSubmitting}
+                aria-invalid={errors.newPassword ? "true" : "false"}
+              />
+              <button
+                type="button"
+                onClick={() => setShowNewPassword(prev => !prev)}
+                className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-gray-700"
+                aria-label={showNewPassword ? "Skrýt nové heslo" : "Zobrazit nové heslo"}
+              >
+                {showNewPassword ? <AiOutlineEyeInvisible size={20} /> : <AiOutlineEye size={20} />}
+              </button>
+            </div>
+            <PasswordStrengthMeter password={newPasswordValue} />
+            {errors.newPassword && (
+              <p className="text-red-500 text-xs italic mt-1">{errors.newPassword.message}</p>
+            )}
+          </div>
+
+          {/* Confirm New Password */}
+          <div className="relative">
+            <label htmlFor="confirmNewPassword" className="block text-sm font-medium mb-1">
+              Potvrdit Nové Heslo
+            </label>
+            <div className="relative">
+              <input
+                type={showConfirmNewPassword ? "text" : "password"}
+                id="confirmNewPassword"
+                {...register("confirmNewPassword")}
+                className={`shadow-sm appearance-none border ${errors.confirmNewPassword ? "border-red-500" : "border-gray-400 dark:border-neutral-600"} rounded w-full py-2 px-3 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50 pr-10`}
+                required
+                disabled={isSubmitting}
+                aria-invalid={errors.confirmNewPassword ? "true" : "false"}
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirmNewPassword(prev => !prev)}
+                className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-gray-700"
+                aria-label={
+                  showConfirmNewPassword
+                    ? "Skrýt potvrzení nového hesla"
+                    : "Zobrazit potvrzení nového hesla"
+                }
+              >
+                {showConfirmNewPassword ? (
+                  <AiOutlineEyeInvisible size={20} />
+                ) : (
+                  <AiOutlineEye size={20} />
+                )}
+              </button>
+            </div>
+            {errors.confirmNewPassword && (
+              <p className="text-red-500 text-xs italic mt-1">
+                {errors.confirmNewPassword.message}
+              </p>
+            )}
+          </div>
+
+          {/* Submit Button */}
+          <div>
+            <button
+              type="submit"
+              className={`w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200 ${isSubmitting ? "opacity-50 cursor-not-allowed" : ""}`}
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? "Aktualizuji..." : "Aktualizovat Heslo"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default ProfilePage;

--- a/apps/iot-app/src/pages/RegisterPage.tsx
+++ b/apps/iot-app/src/pages/RegisterPage.tsx
@@ -14,23 +14,23 @@ import PasswordStrengthMeter from "../components/PasswordStrengthMeter";
 
 const passwordValidation = z
   .string()
-  .min(8, { message: "Password must be at least 8 characters long" })
-  .regex(/[a-z]/, { message: "Password must contain at least one lowercase letter" })
-  .regex(/[A-Z]/, { message: "Password must contain at least one uppercase letter" })
-  .regex(/[0-9]/, { message: "Password must contain at least one number" })
+  .min(8, { message: "Heslo musí mít alespoň 8 znaků" })
+  .regex(/[a-z]/, { message: "Heslo musí obsahovat alespoň jedno malé písmeno" })
+  .regex(/[A-Z]/, { message: "Heslo musí obsahovat alespoň jedno velké písmeno" })
+  .regex(/[0-9]/, { message: "Heslo musí obsahovat alespoň jednu číslici" })
   .regex(/[@$!%*?&]/, {
-    message: "Password must contain at least one special character (@$!%*?&)",
+    message: "Heslo musí obsahovat alespoň jeden speciální znak (@$!%*?&)",
   });
 
 const registerSchema = z
   .object({
-    email: z.string().email({ message: "Invalid email address" }),
-    username: z.string().min(1, { message: "Username is required" }),
+    email: z.string().email({ message: "Neplatná emailová adresa" }),
+    username: z.string().min(1, { message: "Uživatelské jméno je povinné" }),
     password: passwordValidation,
     confirmPassword: z.string(),
   })
   .refine(data => data.password === data.confirmPassword, {
-    message: "Passwords do not match",
+    message: "Hesla se neshodují",
     path: ["confirmPassword"],
   });
 
@@ -66,7 +66,7 @@ function RegisterPage() {
       const errorMessage =
         axios.isAxiosError(err) && err.response?.data?.message
           ? err.response.data.message
-          : "Registration failed. Please try again.";
+          : "Registrace selhala. Zkuste to prosím znovu.";
       toast.error(errorMessage);
     }
   };
@@ -74,7 +74,7 @@ function RegisterPage() {
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-100">
       <div className="p-8 bg-white rounded-lg shadow-md w-full max-w-sm">
-        <h2 className="text-2xl font-semibold text-center text-gray-700 mb-6">Register</h2>
+        <h2 className="text-2xl font-semibold text-center text-gray-700 mb-6">Registrace</h2>
         <form onSubmit={handleSubmit(onSubmit)} noValidate>
           <div className="mb-4">
             <label htmlFor="email" className="block text-gray-700 text-sm font-bold mb-2">
@@ -96,13 +96,13 @@ function RegisterPage() {
           </div>
           <div className="mb-4">
             <label htmlFor="username" className="block text-gray-700 text-sm font-bold mb-2">
-              Username
+              Uživatelské jméno
             </label>
             <input
               type="text"
               id="username"
               {...register("username")}
-              placeholder="Choose a username"
+              placeholder="Zvolte si uživatelské jméno"
               className={`shadow appearance-none border ${errors.username ? "border-red-500" : ""} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:opacity-50`}
               required
               disabled={isSubmitting}
@@ -114,14 +114,14 @@ function RegisterPage() {
           </div>
           <div className="mb-4 relative">
             <label htmlFor="password" className="block text-gray-700 text-sm font-bold mb-2">
-              Password
+              Heslo
             </label>
             <div className="relative">
               <input
                 type={showPassword ? "text" : "password"}
                 id="password"
                 {...register("password")}
-                placeholder="Create a password"
+                placeholder="Vytvořte si heslo"
                 className={`shadow appearance-none border ${errors.password ? "border-red-500" : ""} rounded w-full py-2 px-3 text-gray-700 mb-1 leading-tight focus:outline-none focus:shadow-outline disabled:opacity-50 pr-10`}
                 required
                 disabled={isSubmitting}
@@ -131,7 +131,7 @@ function RegisterPage() {
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
                 className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-600 hover:text-gray-800"
-                aria-label={showPassword ? "Hide password" : "Show password"}
+                aria-label={showPassword ? "Skrýt heslo" : "Zobrazit heslo"}
               >
                 {showPassword ? <AiOutlineEyeInvisible size={20} /> : <AiOutlineEye size={20} />}
               </button>
@@ -143,14 +143,14 @@ function RegisterPage() {
           </div>
           <div className="mb-6 relative">
             <label htmlFor="confirmPassword" className="block text-gray-700 text-sm font-bold mb-2">
-              Confirm Password
+              Potvrdit Heslo
             </label>
             <div className="relative">
               <input
                 type={showConfirmPassword ? "text" : "password"}
                 id="confirmPassword"
                 {...register("confirmPassword")}
-                placeholder="Confirm your password"
+                placeholder="Potvrďte své heslo"
                 className={`shadow appearance-none border ${errors.confirmPassword ? "border-red-500" : ""} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline disabled:opacity-50 pr-10`}
                 required
                 disabled={isSubmitting}
@@ -160,7 +160,9 @@ function RegisterPage() {
                 type="button"
                 onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                 className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-600 hover:text-gray-800"
-                aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                aria-label={
+                  showConfirmPassword ? "Skrýt potvrzení hesla" : "Zobrazit potvrzení hesla"
+                }
               >
                 {showConfirmPassword ? (
                   <AiOutlineEyeInvisible size={20} />
@@ -179,12 +181,12 @@ function RegisterPage() {
               className={`bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline w-full transition-colors duration-200 ${isSubmitting ? "opacity-50 cursor-not-allowed" : ""}`}
               disabled={isSubmitting}
             >
-              {isSubmitting ? "Registering..." : "Register"}
+              {isSubmitting ? "Registruji..." : "Registrovat se"}
             </button>
           </div>
           <div className="mt-4 text-center">
             <Link to="/login" className="text-sm text-blue-500 hover:underline">
-              Already have an account? Login
+              Již máte účet? Přihlásit se
             </Link>
           </div>
         </form>

--- a/apps/iot-app/tailwind.config.js
+++ b/apps/iot-app/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  darkMode: "class", // Explicitly set darkMode strategy
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
- Update backend /login to issue access and refresh tokens.
- Add backend /refresh endpoint to renew access tokens.
- Update frontend context and login page for dual token handling.
- Configure JWT secrets and expiry for access/refresh tokens.
- Axios interceptor now handles silent refresh using stored tokens.